### PR TITLE
Refresh API headers before (re)opening Websockets

### DIFF
--- a/src/Core/ApiConnection.ts
+++ b/src/Core/ApiConnection.ts
@@ -202,13 +202,20 @@ export default class ApiConnection extends TypedEmitter<Events>
         this.setupHttpsClient();
     }
 
+    async getHeaders()
+    {
+        await this.checkRefresh();
+
+        return this.headers;
+    }
+
     private async setupHttpsClient()
     {
         logger.info("Setting up https client");
 
         if (this.accessToken != undefined)
         {
-            logger.info("Deconding token");
+            logger.info("Decoding token");
 
             this.decodedToken = this.decodedToken || {};
 
@@ -253,7 +260,7 @@ export default class ApiConnection extends TypedEmitter<Events>
             return;
         }
     
-        if (!this.refresh && this.accessToken.expired())
+        if (!this.refresh && this.accessToken.expired(15))
         {
             this.refresh = this.refreshInternal();
         }

--- a/src/Core/SubscriptionManager.ts
+++ b/src/Core/SubscriptionManager.ts
@@ -16,14 +16,18 @@ export default class SubscriptionManager
         this.api = api;
         this.emitter = new EventEmitter();
     }
+
     async init()
     {
+        const headers = await this.api.getHeaders();
+
         return new Promise<void>((resolve, reject) =>
         {
-            this.ws = new Websocket("wss://5wx2mgoj95.execute-api.ap-southeast-2.amazonaws.com/dev", { headers: this.api.headers });
-            
+            this.ws = new Websocket("wss://5wx2mgoj95.execute-api.ap-southeast-2.amazonaws.com/dev", { headers });
+
             this.ws.on('open', () =>
             {
+                logger.success('Websocket opened.');
                 resolve();
             });
             

--- a/src/Groups/ServerConnection.ts
+++ b/src/Groups/ServerConnection.ts
@@ -52,7 +52,7 @@ export default class ServerConnection extends TypedEmitter<ConsoleEvents>
     {
         super();
 
-        console.log("Creating server connection");
+        logger.info("Creating server connection");
 
         this.server = server;        
         this.accessProvider = new JsapiAccessProvider(this.server.info.id, new ApiCaller(server.group.manager.api));
@@ -79,7 +79,7 @@ export default class ServerConnection extends TypedEmitter<ConsoleEvents>
     {
         if (this.initializing === undefined)
         {
-            console.log("Doing initialize");
+            logger.info("Doing initialize");
 
             this.initializing = new Promise(async (resolve, reject) =>
             {


### PR DESCRIPTION
## Context

Inside `SubscriptionManager`, the `init()` method is using `this.api.headers` to set the headers for the Websocket connection.

When the `ApiConnection` needs to refresh its access token, it also updates these headers. The class already takes care of checking if a refresh is needed every time its `fetch()` method is called.

However, `SubscriptionManager` does not call `ApiConnection.fetch()` and thus does not trigger a token refresh. This causes `this.api.headers` to become stale when no regular bot traffic is triggering `ApiConnection.fetch()` calls.

When the headers have become stale, the next time `SubscriptionManager` needs to recreate the Websocket, it will do so with an invalid access token and the connection will fail with a `401 Unauthorized`. See #3.

Closes #3.

## Changes

* Added a public `getHeaders()` method to `ApiConnection` which allows external callers to ensure the headers are not stale before consuming them.
* Added a `ApiConnection.getHeaders()` call to `SubscriptionManager.init()` immediately before attempting to create a new Websocket connection.