### PR TITLE
Increase requested resource limit

### DIFF
--- a/src/Groups/Group.ts
+++ b/src/Groups/Group.ts
@@ -186,7 +186,7 @@ export default class Group extends EventEmitter<GroupEvents>
         var updateSub = `group-${name}-update`;
         
         var list: GroupMemberList<T> = new GroupMemberList(`${this.info.name} ${name}`, 
-            () => this.manager.api.fetch('GET', `groups/${id}/${route}`), 
+            () => this.manager.api.fetch('GET', `groups/${id}/${route}?limit=1000`), 
             hasSingle ? user => this.manager.api.fetch('GET', `groups/${id}/${route}/${user}`) : undefined,
             callback => this.manager.subscriptions.subscribe(createSub, id, callback), 
             callback => this.manager.subscriptions.subscribe(deleteSub, id, callback), 

--- a/src/Groups/GroupManager.ts
+++ b/src/Groups/GroupManager.ts
@@ -31,7 +31,7 @@ export default class GroupManager extends EventEmitter<GroupManagerEvents>
         this.api = subscriptions.api;
         this.subscriptions = subscriptions;
         this.groups = new LiveList("groups", 
-            () => this.api.fetch('GET', 'groups/joined'), 
+            () => this.api.fetch('GET', 'groups/joined?limit=1000'), 
             id => this.api.fetch('GET', `groups/${id}`),
             callback => this.subscriptions.subscribe('me-group-create', this.api.userId, callback), 
             callback => this.subscriptions.subscribe('me-group-delete', this.api.userId, callback), 
@@ -47,8 +47,8 @@ export default class GroupManager extends EventEmitter<GroupManagerEvents>
             this.emit('delete', group);
         });
         
-        this.invites = new LiveList("invites", () => this.api.fetch('GET', 'groups/invites'), undefined, callback => this.subscriptions.subscribe('me-group-invite-create', this.api.userId, callback), callback => this.subscriptions.subscribe('me-group-invite-delete', this.api.userId, callback), undefined, data => data.id, invite => invite.info.id, data => new GroupInvite(this, data));
-        this.requests = new LiveList("requests", () => this.api.fetch('GET', 'groups/requests'), undefined, callback => this.subscriptions.subscribe('me-group-request-create', this.api.userId, callback), callback => this.subscriptions.subscribe('me-group-request-delete', this.api.userId, callback), undefined, data => data.id, invite => invite.info.id, data => new GroupRequest(this, data));
+        this.invites = new LiveList("invites", () => this.api.fetch('GET', 'groups/invites?limit=1000'), undefined, callback => this.subscriptions.subscribe('me-group-invite-create', this.api.userId, callback), callback => this.subscriptions.subscribe('me-group-invite-delete', this.api.userId, callback), undefined, data => data.id, invite => invite.info.id, data => new GroupInvite(this, data));
+        this.requests = new LiveList("requests", () => this.api.fetch('GET', 'groups/requests?limit=1000'), undefined, callback => this.subscriptions.subscribe('me-group-request-create', this.api.userId, callback), callback => this.subscriptions.subscribe('me-group-request-delete', this.api.userId, callback), undefined, data => data.id, invite => invite.info.id, data => new GroupRequest(this, data));
     }   
 
     async acceptAllInvites(subscribe: boolean)


### PR DESCRIPTION
## Context

Requested resources from the Alta API are limited to 10 results by default. For a `js-tale` bot that is invited to more than 10 groups this means it won't see all invitations and cannot connect to more than 10 servers.

## Changes

- Increased the limit on several GET requests to increase the number of results returned from the API.