### PR TITLE
Add ban method to GroupMember

### DIFF
--- a/src/Groups/GroupMember.ts
+++ b/src/Groups/GroupMember.ts
@@ -1,4 +1,7 @@
 import Group from "./Group";
+import Logger from '../logger';
+
+const logger = new Logger('GroupMember');
 
 export default class GroupMember
 {
@@ -21,5 +24,11 @@ export default class GroupMember
         this.created = data.created_at;
         this.type = data.type;
         this.bot = data.bot;
+    }
+
+    ban()
+    {
+        return this.group.manager.api.fetch('POST', `groups/${this.group.info.id}/bans/${this.userId}`)
+        .then(logger.thenInfo(`Banned ${this.userId}`));
     }
 }


### PR DESCRIPTION
## Context

The `GroupMember` class currently has no `ban()` method, making it difficult to ban members from groups via the library.

## Changes

- Add `GroupMember.ban()` that calls the same endpoint as `GroupMemberBan.revoke()` but uses a `POST` request.