### PR TITLE
Add ban/unban methods to Group

### DIFF
--- a/src/Groups/Group.ts
+++ b/src/Groups/Group.ts
@@ -255,6 +255,12 @@ export default class Group extends EventEmitter<GroupEvents>
         .then(logger.thenInfo(`Banned ${userId}`));
     }
 
+    unban(userId:number)
+    {
+        return this.manager.api.fetch('DELETE', `groups/${this.info.id}/bans/${userId}`)
+        .then(logger.thenInfo(`Revoked ban on ${userId}`));
+    }
+
     editInfo(edit:any)
     {
         return this.manager.api.fetch('PATCH', `groups/${this.info.id}`, edit);

--- a/src/Groups/Group.ts
+++ b/src/Groups/Group.ts
@@ -249,6 +249,12 @@ export default class Group extends EventEmitter<GroupEvents>
         return this.manager.api.fetch('POST', `groups/${this.info.id}/invites/${userId}`);
     }
 
+    ban(userId:number)
+    {
+        return this.manager.api.fetch('POST', `groups/${this.info.id}/bans/${userId}`)
+        .then(logger.thenInfo(`Banned ${userId}`));
+    }
+
     editInfo(edit:any)
     {
         return this.manager.api.fetch('PATCH', `groups/${this.info.id}`, edit);


### PR DESCRIPTION
## Context

Sometimes we need to pre-emptively ban a player from our server group, even if that player is currently not a member of the group. Unfortunately we can't leverage the new `.ban()` method introduced in #16. We need to be able to modify the `Group` to add and revoke bans on players regardless of their membership status.

## Changes

- Added a `.ban(userId)` method to `Group`.
- Added an `.unban(userId)` method to `Group`.