### PR TITLE
Possible fix to the bot reconnecting to a server and not subscribing to events/reconnection problems

### DIFF
--- a/src/Groups/Server.ts
+++ b/src/Groups/Server.ts
@@ -19,7 +19,7 @@ export interface ServerInfo
     server_status: string;
     scene_index: number;
     region: string;
-    online_ping: string|undefined;
+    last_online: string|undefined;
     description: string;
     playability: number;
     version: string;
@@ -50,7 +50,7 @@ export default class Server extends EventEmitter<ServerEvents>
     
     private evaluateState()
     {        
-        this.isOnline = !!this.info.online_ping && Date.now() - Date.parse(this.info.online_ping) < 10 * 60 * 1000;
+        this.isOnline = !!this.info.last_online && Date.now() - Date.parse(this.info.last_online) < 12 * 1000;
     }
 
     //Provided by LiveList update


### PR DESCRIPTION
Copy of commit comment: replaced online_ping with last_online as it gets sent even when the server goes offline while online_ping doesn't, holding the value of the last time the server was online. also changed the time difference that it will check for now and last_online from 600000 milliseconds (10 minutes) to 12000 milliseconds (12 seconds) because it would better represent when the server is offline or not.

I have done testing and this seems to fix not only this version, but older ones as well to disconnect and reconnect properly.