### PR TITLE
Possible fix for re-connection issues

### DIFF
--- a/src/Groups/Server.ts
+++ b/src/Groups/Server.ts
@@ -19,7 +19,7 @@ export interface ServerInfo
     server_status: string;
     scene_index: number;
     region: string;
-    online_ping: string|undefined;
+    last_online: string|undefined;
     description: string;
     playability: number;
     version: string;
@@ -50,7 +50,7 @@ export default class Server extends EventEmitter<ServerEvents>
     
     private evaluateState()
     {        
-        this.isOnline = !!this.info.online_ping && Date.now() - Date.parse(this.info.online_ping) < 10 * 60 * 1000;
+        this.isOnline = !!this.info.last_online && Date.now() - Date.parse(this.info.last_online) < 12 * 1000;
     }
 
     //Provided by LiveList update


### PR DESCRIPTION
A pull request that was with the master branch now based in the cleanup branch. with testing this fix seems to allow reconnecting to servers that have recently gone down and subscribing to events successfully. possible migration issues with subscriptions and not receiving events, not relating to this change. more testing on this branch needed to confirm, happens on older versions.